### PR TITLE
fix(devops): warning mbind: Operation not permitted after mysql startup #106

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
     volumes:
       - mysql:/var/lib/mysql:rw
 #    user: mysql
+    cap_add:
+      - SYS_NICE  # CAP_SYS_NICE
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
       timeout: 10s


### PR DESCRIPTION
by follow https://dev.mysql.com/doc/refman/8.0/en/resource-groups.html
mysql require the On Linux platforms using systemd and kernel support for Ambient Capabilities (Linux 4.3 or newer), the recommended way to enable CAP_SYS_NICE capability is to modify the MySQL

the solution is https://stackoverflow.com/questions/55559386/how-to-fix-mbind-operation-not-permitted-in-mysql-error-log